### PR TITLE
8. ДЗ: Описание собственного CRD, использование open-source операторов

### DIFF
--- a/kubernetes-operators/clusteradminServiceAccount.yaml
+++ b/kubernetes-operators/clusteradminServiceAccount.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: operators
+  labels:
+    app: otus-homework
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clad
+  namespace: operators
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clusteradmin-homework-ca
+subjects:
+  - kind: ServiceAccount
+    name: clad
+    namespace: operators
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/kubernetes-operators/cr.yaml
+++ b/kubernetes-operators/cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: deployment
+spec:
+  image: "mysql:lts"
+  database: "mysql_homework"
+  password: "XhhiJh7ViJBJqKx4"
+  storage_size: "1Gi"

--- a/kubernetes-operators/crd.yaml
+++ b/kubernetes-operators/crd.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework
+spec:
+  group: otus.homework
+  names:
+    kind: MySQL
+    singular: mysql
+    plural: mysqls
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                  default: "mysql"
+                database:
+                  type: string
+                  pattern: '^[a-zA-Z0-9_]+$'
+                password:
+                  type: string
+                storage_size:
+                  type: string

--- a/kubernetes-operators/deployMysqlOperator.yaml
+++ b/kubernetes-operators/deployMysqlOperator.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rofl-mysql-operator
+  namespace: operators
+  labels:
+    app: rofl-mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rofl-mysql-operator
+  template:
+    metadata:
+      name: rofl-mysql-operator
+      labels:
+        app: rofl-mysql-operator
+    spec:
+      # serviceAccountName: clad
+      serviceAccountName: rofl
+      containers:
+        - name: rofl-mysql-operator
+          image: roflmaoinmysoul/mysql-operator:1.0.0
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      

--- a/kubernetes-operators/roflServiceAccount.yaml
+++ b/kubernetes-operators/roflServiceAccount.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: operators
+  labels:
+    app: otus-homework
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rofl
+  namespace: operators
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: rofl-operator-role
+  namespace: default
+  labels:
+    app: otus-homework
+rules:
+  - verbs:
+      - create
+      - delete
+    apiGroups:
+      - "*"
+    resources:
+      - services
+      - persistentvolumeclaims
+  - verbs:
+      - create
+    apiGroups:
+      - ""
+    resources:
+      - events
+  - verbs:
+      - "*"
+    apiGroups:
+      - apps
+    resources:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rofl-operator-role
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: rofl
+    namespace: operators
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rofl-operator-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rofl-operator-manage-pv-role
+  labels:
+    app: otus-homework
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+    apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+  - verbs:
+      - "*"
+    apiGroups:
+      - otus.homework
+    resources:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rofl-operator-manage-pv-rb
+subjects:
+  - kind: ServiceAccount
+    name: rofl
+    namespace: operators
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rofl-operator-manage-pv-role

--- a/kubernetes-operators/starXstar/cr-mysql-sdk.yaml
+++ b/kubernetes-operators/starXstar/cr-mysql-sdk.yaml
@@ -1,0 +1,11 @@
+apiVersion: mysql.otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-sdk
+spec:
+  mysql:
+    rootPassword: dG9vcg==
+  storage:
+    capacity: 2G
+  
+  

--- a/kubernetes-operators/starXstar/crd.yaml
+++ b/kubernetes-operators/starXstar/crd.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.mysql.otus.homework
+spec:
+  group: mysql.otus.homework
+  names:
+    kind: MySQL
+    listKind: MySQLList
+    plural: mysqls
+    singular: mysql
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: MySQL is the Schema for the mysqls API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of MySQL
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of MySQL
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/kubernetes-operators/starXstar/deployMysqlOperator.yaml
+++ b/kubernetes-operators/starXstar/deployMysqlOperator.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sdk-mysql-operator
+  namespace: operators
+  labels:
+    app: sdk-mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sdk-mysql-operator
+  template:
+    metadata:
+      name: sdk-mysql-operator
+      labels:
+        app: sdk-mysql-operator
+    spec:
+      serviceAccountName: clad
+      containers:
+        - name: sdk-mysql-operator
+          image: ilyang/mysql-operator:v0.0.1
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      

--- a/kubernetes-operators/starXstar/workflow.sh
+++ b/kubernetes-operators/starXstar/workflow.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# 1. Install operator-sdk
+# Ref: https://sdk.operatorframework.io/docs/installation/
+
+# 2. Find and add Helm Chart repo locally
+helm repo add homeenterpriseinc https://homeenterpriseinc.github.io/helm-charts/
+
+# 3. Init operator-sdk project
+mkdir "mysql-operator" && cd mysql-operator
+operator-sdk init --domain otus.homework --plugins helm --helm-chart=homeenterpriseinc/mysql --group=mysql --kind=MySQL --version=v1
+
+# 4. Check and fix (на самом деле нет :) ) generated config
+
+# 5. Build and push docker image from project dir
+make docker-build docker-push IMG="ilyang/mysql-operator:v0.0.1"
+
+# 6. Prepare operator to deploy into cluster
+# make deploy
+cp config/crd/bases/* ../ # тут описание crd
+cp config/samples/mysql* ./ # тут образец CR со всеми полями, извлеченными из values Helm-чарта


### PR DESCRIPTION
# Выполнено ДЗ №7

 - [x] Основное ДЗ
 - [x] Задание со *
 - [x] Задание с **

## В процессе сделано:
 - Описан, развернут и протестирован оператор roflmaoinmysoul/mysql-operator:1.0.0
 - Создан отдельный ServiceAccount с ограниченными правами, достаточными для работы оператора
 - Создан развернут и протестирован собственный оператор для установки mysql

## Как запустить проект:
Для основного задания
 - Применить последовательно манифесты 
     clusteradminServiceAccount.yaml
     crd.yaml     
 - Применить манифест deployMysqlOperator.yaml с использованием SA=clad (перекомментировать строку serviceAccountName)
 - Применить манифест cr.yaml для проверки работы оператора
 - После проверки удалить из кластера манифест cr.yaml

Для задания *
- Применить манифест roflServiceAccount.yaml
- Исправить манифест deployMysqlOperator.yaml на использование serviceAccountName: rofl
- Сделать редеплой оператора командой kubectl rollout restart -n operators deployment/rofl-mysql-operator
- Применить манифест cr.yaml для проверки работы оператора
- После проверки удалить из кластера установленные манифесты cr.yaml deployMysqlOperator.yaml crd.yaml  

Для задания **
- Применить манифесты для установки "самодельного" оператора
    kubernetes-operators/clusteradminServiceAccount.yaml
    kubernetes-operators/starXstar/crd.yaml
    kubernetes-operators/starXstar/deployMysqlOperator.yaml
- Применить манифест kubernetes-operators/starXstar/cr-mysql-sdk.yaml для установки Mysql с использованием этого оператора

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
